### PR TITLE
Feature/fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,7 @@ GitHub Actions are used to collect data on releases (via repository tags) and is
 
 ## hugo site
 
-The dev/design site is generated with [Hugo](https://gohugo.io/) using the [Docsy](https://www.docsy.dev/) theme.
-
-Because GitHub currently only supports publishing User and Organization sites from `master`, development on the site and scripts should be done on `develop`. The Hugo site is automatically compiled and published from the `develop` branch and published to `master`.
-
+The dev/design site is generated with [Hugo](https://gohugo.io/) using the [Docsy](https://www.docsy.dev/) theme. The Hugo site is automatically compiled from the `main` branch and published to `gh-pages`.
 
 ## setup
 

--- a/config.toml
+++ b/config.toml
@@ -99,6 +99,7 @@ url_latest_version = "https://example.com"
 
 # Repository configuration (URLs for in-page links to opening issues and suggesting changes)
 github_repo = "https://github.com/Princeton-CDH/princeton-cdh.github.io"
+github_org_url = "https://github.com/Princeton-CDH/"
 # An optional link to a related project repo. For example, the sibling repository where your product code lives.
 #github_project_repo = "https://github.com/google/docsy"
 


### PR DESCRIPTION
* Add CDH org github parameter, fixing broken links e065076
* Update README to reflect new branch structure f84677c

The `github_org_url` param was defined in `config.toml` on the develop branch (visible not through the github UI, but with a `git switch develop`), so we may want to check to see if any other problem creeped in while changing our git workflow.

The following links that were broken should now work:
* Iteration reports: Active projects & Releases
* Project reports: Releases

Closes #23 