### PR TITLE
Add logic for "skipped" iterations / non-iteration weeks in the schedule

### DIFF
--- a/.github/summarize_iterations.py
+++ b/.github/summarize_iterations.py
@@ -57,18 +57,14 @@ def summarize_iterations():
 
     with open('data/iterations.json') as f:
         iteration_data = json.load(f)
+        # filter iteration data to those that should be included in summary:
+        # - skip any with end date unset (allow future iterations with end date unspecified)
+        # - skip any flagged as "skip" for display in dev schedule
+        iteration_data = [it for it in iteration_data if not it.get('skip') or 'to' not in it]
 
         issue_index = 0
 
         for i, iteration in enumerate(iteration_data):
-            # TOOD: if/when we consolidate iterations.json
-            # and iteration-summary.json:
-            # don't recalculate values that are already present
-
-            # allow defining start of new iteration without specifying end
-            if 'to' not in iteration:
-                continue
-
             # use current iteration start as beginning of date range
             # and next iteration start as end
             # (make sure we account for all events without having to set
@@ -106,10 +102,6 @@ def summarize_iterations():
         # not enough data; skip
         if i < 2:
             continue
-        # alow next iteration defined start but not end
-        if 'to' not in iteration:
-            continue
-
         iteration['dev']['velocity'] = average(
             [it['dev']['points'] for it in iteration_data[i - 2:i + 1]])
         iteration['design']['velocity'] = average(

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ npm install
 
 ## Creating iteration reports
 
-Update iteration definitions as needed in `iterations.json` if you need to add the dates for the next iteration (although these will likely be populated ahead of time now that we are using that data file for quarterly development shcedule). 
+Update iteration definitions as needed in `iterations.json` if you need to add the dates for the next iteration (although these will likely be populated ahead of time now that we are using that data file for quarterly development shcedule).
 
 Pull the latest changes from GitHub to get data added by the issue collection and iteration summary GitHub Action scripts, which run on Saturdays.
 
@@ -54,7 +54,17 @@ Edit `iterations.json` data file to add the dates for all iterations during the 
 For each iteration, add:
 - projects: the list of projects projected to be active that iteration
 - partial: optional, list of projects that are in planning or wrap up phases
-- notes: optional; dictionary with list of notes per project for display in the schedule; when two notes are displayed, the second will be displayed 
-the second week of the iteration
+- notes: optional; dictionary with list of notes per project for display in the schedule; when two notes are displayed, the second will be displayed the second week of the iteration.
 
 Be sure to add project colors and partial colors to `_quarterly_schedule.scss` when you add new projects to the schedule.
+
+Iterations may be a variable number of weeks; they are typically two, but one and two week iterations are supported by the layout. To include a non-iteration week or time period on the calendar, add the property "skip" to the iteration definition. To display a label on the schedule, add text in a "comment" field. For example:
+
+```
+    {
+        "from": "2021-06-28",
+        "to": "2021-07-02",
+        "comment": "R&D week",
+        "skip": "yes"
+    }
+```

--- a/assets/scss/_quarterly_schedule.scss
+++ b/assets/scss/_quarterly_schedule.scss
@@ -8,15 +8,15 @@
 	}
 	th.iteration {
 		writing-mode: vertical-rl;
-		-webkit-writing-mode: vertical-rl;		
-        -ms-writing-mode: vertical-rl;
+		-webkit-writing-mode: vertical-rl;
+		-ms-writing-mode: vertical-rl;
 	}
 
 	tr {
 		background-color: transparent !important;
 
 		&.iteration-start {
-			border-top: 2px solid darkgray !important;			
+			border-top: 2px solid darkgray !important;
 		}
 
 		&:nth-child(even) {
@@ -24,7 +24,7 @@
 				border-top: 2px solid gray(169, 1) !important;
 			}
 		}
-	}	
+	}
 
 	td {
 		height: 50px;
@@ -58,11 +58,11 @@
 
 	.ppa {
 		background-color: #f05b69;
-		color: white;	
+		color: white;
 		&.partial {
 			background-color: rgba(240,91,105,0.5);
 			color:black;
-		}	
+		}
 	}
 
 	.mep {
@@ -78,9 +78,10 @@
 			background-color: rgba(206, 41, 73, 0.5);
 		}
 	}
-	
-    .out { 
-    	background-color: #b7b7b7; 
-    }
+
+	.out {
+		background-color: #cdcdcd;
+		text-align: center;
+	}
 
 }

--- a/content/blog/iteration-reports/2021-07-26/index.md
+++ b/content/blog/iteration-reports/2021-07-26/index.md
@@ -9,7 +9,7 @@ This iteration we made significant progress on PPA. All remaining planned work t
 
 There was a smattering of progress on other projects as well. For the CDH website, we completed work to setup a new visual testing review workflow with [Percy](https://percy.io/), which we hope will save time and improve our design implementation testing across projects.  We continued to be paused on Geniza, but we had one issue closed that should have been accepted before, but was left open based on design feedback and changes requested rather than functionality. On Startwords, we also had a very minor style bugfix resolved.
 
-We extended this iteration for 3 weeks to account for vacation and the ACH2021 conference last week. We completed 10 developments points, and have a rolling development velocity of 14.3 points (the chart below is currently inaccurate because it is including the off-week in our iteration schedule when calculating rolling velocity).
+We extended this iteration for 3 weeks to account for vacation and the ACH2021 conference last week. We completed 10 developments points, and have a rolling development velocity of 14.3 points.
 
 ## Demos
 {{< figure src="featured-percy-visualreview.png" caption="Screenshot from Percy showing an example of visual review for a page on CDH web">}}

--- a/content/blog/iteration-reports/2021-08-09/index.md
+++ b/content/blog/iteration-reports/2021-08-09/index.md
@@ -5,7 +5,7 @@ iteration_start: 2021-07-26
 layout: iterationreport
 ---
 
-We had multiple projects active this iteration, roughly divided across developers on the team. The planned work for PPA spilled over and needed to be completed; work started on updates for CDH web identified in the recent project charter; and work continued on maintenance updates for Derrida's Margins.  We closed **24** issues and a total of **9** points for a rolling velocity of **11.3** (the chart below is still inaccurate due to the skipped iteration being included). The lower velocity reflects the kind of work we're doing (including some maintenance), as well as other things going on, including the transition with some staff starting to work on campus again.
+We had multiple projects active this iteration, roughly divided across developers on the team. The planned work for PPA spilled over and needed to be completed; work started on updates for CDH web identified in the recent project charter; and work continued on maintenance updates for Derrida's Margins.  We closed **24** issues and a total of **9** points for a rolling velocity of **11.3**. The lower velocity reflects the kind of work we're doing (including some maintenance), as well as other things going on, including the transition with some staff starting to work on campus again.
 
 ## Project-specific updates
 

--- a/data/iteration_summary.json
+++ b/data/iteration_summary.json
@@ -1289,7 +1289,7 @@
         },
         "dev": {
             "points": 15,
-            "issues": 28,
+            "issues": 29,
             "velocity": 17.0
         },
         "design": {
@@ -1299,33 +1299,13 @@
         },
         "project_issues": {
             "ppa-django": 17,
-            "cdh-web": 4,
+            "cdh-web": 5,
             "geniza": 11
         },
         "project_points": {
             "ppa-django": 15,
             "cdh-web": 1,
             "geniza": 5
-        }
-    },
-    {
-        "from": "2021-06-28",
-        "to": "2021-07-02",
-        "comment": "R&D week",
-        "dev": {
-            "points": 0,
-            "issues": 1,
-            "velocity": 11.0
-        },
-        "design": {
-            "points": 0,
-            "velocity": 2.0
-        },
-        "project_issues": {
-            "cdh-web": 1
-        },
-        "project_points": {
-            "cdh-web": 0
         }
     },
     {
@@ -1355,7 +1335,7 @@
         "dev": {
             "points": 10,
             "issues": 12,
-            "velocity": 8.33
+            "velocity": 14.33
         },
         "design": {
             "points": 0,
@@ -1395,11 +1375,11 @@
         "dev": {
             "points": 9,
             "issues": 24,
-            "velocity": 6.33
+            "velocity": 11.33
         },
         "design": {
             "points": 0,
-            "velocity": 0.0
+            "velocity": 2.0
         },
         "project_issues": {
             "cdh-ansible": 3,

--- a/data/iterations.json
+++ b/data/iterations.json
@@ -245,7 +245,8 @@
     {
         "from": "2021-06-28",
         "to": "2021-07-02",
-        "comment": "R&D week"
+        "comment": "R&D week",
+        "skip": "yes"
     },
     {
         "from": "2021-07-05",

--- a/layouts/blog/quarterlyschedule.html
+++ b/layouts/blog/quarterlyschedule.html
@@ -67,17 +67,23 @@ date_range:
         {{/* rowspan to indicate iteration length */}}
         <td rowspan="{{ $scratch.Get "iteration_weeks" }}"></td>
 
-        {{ range $projects }}
-        {{/* for each projects, output a table cell; set class if active; add notes if present; if project is in partial list, add partial class */}}
-        <td class="{{ if in $iteration.projects . }}{{ . }}{{ end }}{{ if (and (isset $iteration "partial") (in $iteration.partial .)) }} partial{{ end }}">
-            {{/* display first note for this project if any */}}
-            {{ if $iteration.notes }}
-                {{ $project_notes := index $iteration.notes .}}
-                {{ if $project_notes }}
-                    {{ index $project_notes 0 }}
+        {{ if $iteration.skip }} {{/* display scheduled non-iteration weeks */}}
+        <td colspan="{{ len $projects }}" class="out">{{ $iteration.comment }}</td>
+        {{ else }}
+
+            {{ range $projects }}
+            {{/* for each projects, output a table cell; set class if active; add notes if present; if project is in partial list, add partial class */}}
+            <td class="{{ if in $iteration.projects . }}{{ . }}{{ end }}{{ if (and (isset $iteration "partial") (in $iteration.partial .)) }} partial{{ end }}">
+                {{/* display first note for this project if any */}}
+                {{ if $iteration.notes }}
+                    {{ $project_notes := index $iteration.notes .}}
+                    {{ if $project_notes }}
+                        {{ index $project_notes 0 }}
+                    {{ end }}
                 {{ end }}
+            </td>
             {{ end }}
-        </td>
+
         {{ end }}
     </tr>
     {{/* second week of iteration */}}


### PR DESCRIPTION
- add & document a convention for marking iterations to be skipped
- customize display for skipped iteration on quarterly schedule layout
- ignore skip iterations when summarizing iterations

I also updated the two recent iteration report posts to remove the text where I said the reported velocity was inaccurate, since now it is accurate!