### PR TITLE
Schedule updates

### DIFF
--- a/assets/scss/_quarterly_schedule.scss
+++ b/assets/scss/_quarterly_schedule.scss
@@ -6,7 +6,7 @@
 	th.project {
 		width: 10em;
 	}
-	th .iteration {
+	th.iteration {
 		writing-mode: vertical-rl;
 	}
 
@@ -77,9 +77,18 @@
 		}
 	}
 
-	.out {
-		background-color: #cdcdcd;
+    .out {
+    	background-color: #cdcdcd;
 		text-align: center;
+    }
+
+	.derrida {
+		background-color: #175498;
+		color: white;
+		&.partial {
+			background-color: rgba(23, 84, 152,0.4);
+			color:black;
+		}
 	}
 
 }

--- a/assets/scss/_quarterly_schedule.scss
+++ b/assets/scss/_quarterly_schedule.scss
@@ -6,7 +6,7 @@
 	th.project {
 		width: 10em;
 	}
-	th.iteration {
+	th .iteration {
 		writing-mode: vertical-rl;
 	}
 

--- a/content/blog/2021-08-11-fall-schedule.md
+++ b/content/blog/2021-08-11-fall-schedule.md
@@ -1,0 +1,10 @@
+---
+title: Fall development schedule, September — December 2021
+layout: quarterlyschedule
+date: 2021-08-11
+date_range:
+    start: "2021-08-23"
+    end: "2021-12-26"
+---
+
+Development schedule for Fall 2021.

--- a/data/iterations.json
+++ b/data/iterations.json
@@ -284,27 +284,81 @@
     {
         "from": "2021-08-23",
         "to": "2021-09-03",
-        "projects": ["geniza", "maintenance"],
-        "partial": ["geniza", "maintenance"],
+        "projects": ["geniza", "maintenance", "derrida", "mep"],
+        "partial": ["geniza", "maintenance", "derrida", "mep"],
         "notes": {
             "geniza": ["chartering Y2"],
-            "maintenance": ["design systematization"]
+            "maintenance": ["design systematization"],
+            "derrida": ["", "data exports"],
+            "mep": ["PUL migration"]
         }
     },
     {
         "from": "2021-09-06",
         "to": "2021-09-17",
-        "projects": ["geniza"],
-        "partial": ["geniza"],
+        "projects": ["geniza", "derrida"],
+        "partial": ["geniza", "derrida"],
         "notes": {
+            "derrida": ["", "archive site"]
         }
     },
     {
         "from": "2021-09-20",
         "to": "2021-10-01",
-        "projects": [],
+        "projects": ["geniza"],
         "partial": [],
         "notes": {
+        }
+    },
+    {
+        "from": "2021-10-04",
+        "to": "2021-10-15",
+        "projects": ["geniza"],
+        "partial": [],
+        "notes": {
+        }
+    },
+    {
+        "from": "2021-10-18",
+        "to": "2021-10-29",
+        "projects": ["geniza", "cdh-web"],
+        "partial": ["cdh-web"],
+        "notes": {
+            "cdh-web": ["planning & design"]
+        }
+    },
+    {
+        "from": "2021-11-01",
+        "to": "2021-11-12",
+        "projects": ["cdh-web", "geniza"],
+        "partial": ["geniza"],
+        "notes": {
+            "cdh-web": ["phase II development"]
+        }
+    },
+    {
+        "from": "2021-11-15",
+        "to": "2021-11-26",
+        "projects": ["geniza"],
+        "partial": [],
+        "notes": {
+        }
+    },
+    {
+        "from": "2021-11-29",
+        "to": "2021-12-10",
+        "projects": ["geniza"],
+        "partial": [],
+        "notes": {
+        }
+    },
+    {
+        "from": "2021-12-13",
+        "to": "2021-12-24",
+        "projects": ["ppa"],
+        "partial": [],
+        "notes": {
+            "ppa": ["ECCO excerpts", "grouping works"]
         }
     }
 ]

--- a/data/iterations.json
+++ b/data/iterations.json
@@ -238,7 +238,7 @@
         "partial": ["cdh-web", "geniza"],
         "notes": {
             "cdh-web": ["chartering + design problem identification"],
-            "ppa": ["Implement Gale/ECCO import"],
+            "ppa": ["Gale/ECCO import"],
             "geniza": ["visual design"]
         }
     },
@@ -251,22 +251,24 @@
     {
         "from": "2021-07-05",
         "to": "2021-07-23",
-        "projects": ["maintenance", "ppa", "cdh-web"],
-        "partial": ["ppa", "cdh-web"],
+        "projects": ["maintenance", "ppa", "cdh-web", "derrida"],
+        "partial": ["ppa", "cdh-web", "derrida", "maintenance"],
         "notes": {
-            "maintenance": ["archive Derrida's Margins", "PUL migrations"],
             "ppa": ["excerpt support"],
-            "cdh-web": ["design"]
+            "cdh-web": ["design"],
+            "derrida": ["planning"],
+            "maintenance": ["ansible updates"]
         }
     },
     {
         "from": "2021-07-26",
         "to": "2021-08-06",
-        "projects": ["cdh-web", "maintenance"],
-        "partial": ["maintenance"],
+        "projects": ["cdh-web", "ppa", "derrida"],
+        "partial": ["maintenance", "ppa", "derrida"],
         "notes": {
             "cdh-web": ["site search"],
-            "maintenance": ["design systematization"]
+            "ppa": ["", "3.7 release"],
+            "derrida": ["v1.2.5 bugfix release"]
         }
     },
     {
@@ -282,10 +284,11 @@
     {
         "from": "2021-08-23",
         "to": "2021-09-03",
-        "projects": ["geniza"],
-        "partial": ["geniza"],
+        "projects": ["geniza", "maintenance"],
+        "partial": ["geniza", "maintenance"],
         "notes": {
-            "geniza": ["chartering Y2"]
+            "geniza": ["chartering Y2"],
+            "maintenance": ["design systematization"]
         }
     },
     {


### PR DESCRIPTION
- revised iteration data to better reflect what we actually did (i.e., extended ppa), and added derrida as a separate project instead of lumping under maintenance; can be seen on the summer dev schedule post
- added a draft fall schedule based on what @thatbudakguy discussed and whiteboarded out together; PPA and CDH web both could move depending on PI availability and other commitments

already seems like a lot of projects on the schedule, but what do you think about adding startwords for the iteration around when we're hoping to publish issue 2?