### PR TITLE
adjust iteration report titles to reflect iteration dates

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -19,7 +19,7 @@ jobs:
     - name: setup hugo
       uses: peaceiris/actions-hugo@v2
       with:
-        hugo-version: '0.74.2'
+        hugo-version: '0.87.0'
         extended: true
 
     - name: Use Node.js

--- a/README.md
+++ b/README.md
@@ -39,10 +39,9 @@ Create a new iteration report using the iteration report page bundle archetype w
 hugo new --kind iteration-report blog/iteration-reports/`date +'%Y-%m-%d'`
 ```
 
-The iteration report archetype assumes it is run on the first day of the new iteration; previous iteration start is calculated accordingly, and should be edited when necessary. Make sure the `iteration_start` date matches the iteration start value in the iterations summary data file.
+The iteration report archetype assumes it is run on the first day of the new iteration; previous iteration start is calculated accordingly, and should be edited when necessary. Make sure the `iteration_start` date matches the iteration start value in the iterations summary data file, and update the post title to reflect the iteration dates.
 
 Edit the new post to add content and any demo or featured content, then commit and push to GitHub to publish.
-
 
 ## Creating quarterly dev schedule
 

--- a/archetypes/iteration-report/index.md
+++ b/archetypes/iteration-report/index.md
@@ -1,8 +1,9 @@
 ---
-title: "{{ now.Format "January 2, 2006" }}"
+title: "{{ dateFormat "Jan 2 " (now.AddDate 0 0 -14 ) }} - {{ dateFormat "Jan 2, 2006" (now.AddDate 0 0 -3 ) }}"
 date: {{ now.Format "2006-01-02" }}
 iteration_start: {{ dateFormat "2006-01-02" (now.AddDate 0 0 -14 ) }}
 layout: iterationreport
+slug: "{{ now.Format "02" }}"
 ---
 
 add summary paragraphs(s) about the iteration

--- a/content/blog/iteration-reports/2020-06-30.md
+++ b/content/blog/iteration-reports/2020-06-30.md
@@ -1,8 +1,11 @@
 ---
-title: June 30th, 2020
+title: Jun 15 — 26, 2020
 date: 2020-06-30
 iteration_start: 2020-06-15
 layout: iterationreport
+slug: "30"
+aliases:
+  - /blog/2020/06/june-30th-2020/
 ---
 
 Lots of progress on _Startwords_, but no official release until Issue 1 is ready.

--- a/content/blog/iteration-reports/2020-07-21.md
+++ b/content/blog/iteration-reports/2020-07-21.md
@@ -1,8 +1,11 @@
 ---
-title: July 21st, 2020
+title: Jun 29 - Jul 17, 2020
 date: 2020-07-21
 iteration_start: 2020-06-29
 layout: iterationreport
+slug: "21"
+aliases:
+  - /blog/2020/07/july-21st-2020/
 ---
 
 

--- a/content/blog/iteration-reports/2020-08-10.md
+++ b/content/blog/iteration-reports/2020-08-10.md
@@ -1,8 +1,11 @@
 ---
-title: August 10th, 2020
+title: Jul 20 - Aug 7, 2020
 date: 2020-08-10
 iteration_start: 2020-07-20
 layout: iterationreport
+slug: "10"
+aliases:
+  - /blog/2020/08/august-10th-2020/
 ---
 
 

--- a/content/blog/iteration-reports/2020-08-24.md
+++ b/content/blog/iteration-reports/2020-08-24.md
@@ -1,8 +1,11 @@
 ---
-title: August 24th, 2020
+title: Aug 10 - 20, 2020
 date: 2020-08-24
 iteration_start: 2020-08-10
 layout: iterationreport
+slug: "24"
+aliases:
+  - /blog/2020/08/august-24th-2020/
 ---
 
 Not a lot of development work reported on GitHub because the primary team focus continues to be planning the new Research Partnership project. This iteration also included time spent on two internal project retrospectives (Shakespeare and Company Project, PEMM) and a CDH Retreat.

--- a/content/blog/iteration-reports/2020-09-08/index.md
+++ b/content/blog/iteration-reports/2020-09-08/index.md
@@ -1,8 +1,11 @@
 ---
-title: September 8th, 2020
+title: Aug 24 - Sep 4, 2020
 date: 2020-09-08
 iteration_start: 2020-08-24
 layout: iterationreport
+slug: "08"
+aliases:
+  - /blog/2020/09/september-8th-2020/
 ---
 
 The last iteration we continued to spend time on project maintenance and updates. Closed issues on *Startwords* and the pucas release are continuing and closing out work from the previous iterations.  Active work this iteration that is incomplete and not reflected in the closed tickets include django/mezzanine upgrades for cdhweb, and refactoring PPA to remove an outdated SolrClient dependency and use parasolr instead. We also have now migrated our first repositories to use **main** as the production branch name.

--- a/content/blog/iteration-reports/2020-09-21.md
+++ b/content/blog/iteration-reports/2020-09-21.md
@@ -1,8 +1,11 @@
 ---
-title: September 21st, 2020
+title: Sep 7 - 18, 2020
 date: 2020-09-21
 iteration_start: 2020-09-07
 layout: iterationreport
+slug: "21"
+aliases:
+  - /blog/2020/09/september-21st-2020/
 ---
 
 This iteration included work to complete cdh-web version 2.7, which consisted of maintenance upgrades and a few helpful features for fall; maintenance and bug fixes on PPA, including a refactor to use in-house Solr library parasolr, removing a dependency on a forked, unmaintained SolrClient; and continued progress on _Startwords_.

--- a/content/blog/iteration-reports/2020-10-05.md
+++ b/content/blog/iteration-reports/2020-10-05.md
@@ -1,8 +1,11 @@
 ---
-title: October 5th, 2020
+title: Sep 21 - Oct 2, 2020
 date: 2020-10-05
 iteration_start: 2020-09-21
 layout: iterationreport
+slug: "05"
+aliases:
+  - /blog/2020/10/october-5th-2020/
 ---
 
 This iteration marked our official start of work on the Geniza research partnership, now that the charter has been signed. We made progress on data modeling and a preliminary search prototype, but since none of those tasks have been completed they aren't reflected in the issues and points below. We also saw a lot of activity on _Startwords_, as the team makes the push to complete remaining functionality and styles needed for the project launch. We also made progress on PPA maintenance and bug fixes, although the fixes have not yet been released to production, and one bug fix is ready for testing but blocked waiting on HathiTrust restoring rsync dataset access.

--- a/content/blog/iteration-reports/2020-10-19/index.md
+++ b/content/blog/iteration-reports/2020-10-19/index.md
@@ -1,8 +1,11 @@
 ---
-title: October 19th, 2020
+title: Oct 5 - 15, 2020
 date: 2020-10-19
 iteration_start: 2020-10-05
 layout: iterationreport
+slug: "19"
+aliases:
+  - /blog/2020/10/october-19th-2020/
 ---
 
 Last iteration we put a lot of time and effort into Startwords as we get close to our issue 1 deadline and launch date, although that's not reflected in the number of tickets closed on GitHub.

--- a/content/blog/iteration-reports/2020-11-02/index.md
+++ b/content/blog/iteration-reports/2020-11-02/index.md
@@ -1,8 +1,11 @@
 ---
-title: "November 2, 2020"
+title: "Oct 19 - 31, 2020"
 date: 2020-11-02
 iteration_start: 2020-10-19
 layout: iterationreport
+slug: "02"
+aliases:
+  - /blog/2020/11/november-2-2020/
 ---
 
 Very pleased to report that this past iteration we finally published [Issue One of _Startwords_](https://startwords.cdh.princeton.edu/issues/1/). The velocity charts below reflect the effort to get this out the door, including completion of design and implementation on an experimental piece and a large amount of work to finish converting the long "Data Beyond Vision" essay and related snippets to markdown, and to finish custom styles for the essay, including PDF styles.

--- a/content/blog/iteration-reports/2020-11-16/index.md
+++ b/content/blog/iteration-reports/2020-11-16/index.md
@@ -1,13 +1,16 @@
 ---
-title: "November 16, 2020"
+title: "Nov 2 - 14, 2020"
 date: 2020-11-16
 iteration_start: 2020-11-02
 layout: iterationreport
+slug: "16"
+aliases:
+  - /blog/2020/11/november-16-2020/
 ---
 
 This iteration we made substantial progress on our Geniza search prototyping, most notably implementing the first two steps towards a prototype of the holistic search interface that Gissoo has been designing.
 
-We also made some updates and fixed some bugs for CDH web, towards a maintenance release that will go out early this iteration. 
+We also made some updates and fixed some bugs for CDH web, towards a maintenance release that will go out early this iteration.
 
 ## Demos
 {{< figure src="featured-cluster-prototype.png" caption="Screenshot of the experimental Geniza cluster search prototype">}}

--- a/content/blog/iteration-reports/2020-11-30/index.md
+++ b/content/blog/iteration-reports/2020-11-30/index.md
@@ -1,8 +1,11 @@
 ---
-title: "November 30, 2020"
+title: "Nov 16 - 27, 2020"
 date: 2020-11-30
 iteration_start: 2020-11-16
 layout: iterationreport
+slug: "30"
+aliases:
+  - /blog/2020/11/november-30-2020/
 ---
 
 This was our last scheduled iteration for working on Geniza prototyping,

--- a/content/blog/iteration-reports/2020-12-14.md
+++ b/content/blog/iteration-reports/2020-12-14.md
@@ -1,13 +1,15 @@
 ---
-title: "December 14, 2020"
+title: "Nov 30 - Dec 12, 2020"
 date: 2020-12-14
 iteration_start: 2020-11-30
 layout: iterationreport
+aliases:
+  - /blog/2020/12/december-14-2020/
 ---
 
 This iteration we paused active software development on the Geniza project, although design research and work on sitemap and continued, along with planning for the next phase.
 
-We shifted development efforts to an infrastructure migration for the CDH website and planning for CDH web 3.0, which consists of a major migration to move content management functionality from Mezzanine to Wagtail. 
+We shifted development efforts to an infrastructure migration for the CDH website and planning for CDH web 3.0, which consists of a major migration to move content management functionality from Mezzanine to Wagtail.
 
 There was also development effort on Shakespeare and Company Project with the main goal of generating updated dataset exports in January, although we did address a handful of small bugs.
 

--- a/content/blog/iteration-reports/2021-01-11/index.md
+++ b/content/blog/iteration-reports/2021-01-11/index.md
@@ -1,8 +1,11 @@
 ---
-title: "January 11, 2021"
+title: "Dec 14, 2020 - Jan 8, 2021"
 date: 2021-01-11
 iteration_start: 2020-12-14
 layout: iterationreport
+slug: "11"
+aliases:
+  - /blog/2021/01/january-11-2021/
 ---
 
 Due to the holidays and planned vacations, we decided to take a long iteration spanning from December 14th to the end of the first week in January.

--- a/content/blog/iteration-reports/2021-02-01/index.md
+++ b/content/blog/iteration-reports/2021-02-01/index.md
@@ -1,11 +1,14 @@
 ---
-title: "February 1, 2021"
+title: "Jan 11 - 22, 2021"
 date: 2021-02-01
 iteration_start: 2021-01-11
 layout: iterationreport
+slug: "01"
+aliases:
+  - /blog/2021/02/february-1-2021/
 ---
 
-Last iteration we made substantial progress on the cdhweb "exodus" from mezzanine to wagtail: features related to editing and "exodizing" content pages and uploaded images have been tested and accepted, and more work is underway. 
+Last iteration we made substantial progress on the cdhweb "exodus" from mezzanine to wagtail: features related to editing and "exodizing" content pages and uploaded images have been tested and accepted, and more work is underway.
 
 Active development was paused on Geniza, but design work continued on a revised sitemap / site flow diagram for the new PGP site and reports to share information from usability testing.
 

--- a/content/blog/iteration-reports/2021-02-15.md
+++ b/content/blog/iteration-reports/2021-02-15.md
@@ -1,8 +1,11 @@
 ---
-title: "February 15, 2021"
+title: "Feb 1 - 13, 2021"
 date: 2021-02-15
 iteration_start: 2021-02-01
 layout: iterationreport
+slug: 15
+aliases:
+  - /blog/2021/02/february-1-2021/
 ---
 
 This iteration we closed a significant number of issues for the Geniza project; the completed development work was all related to prototypes from the first phase (IIIF images with transcription, experimenting with eScriptorium, and two stories for a multilingual prototype). We also closed two design issues related to the sitemap & site flow diagram and the holistic search. We started implementing the new Geniza database and admin site, but have not yet delivered any issues for testing.

--- a/content/blog/iteration-reports/2021-03-01/index.md
+++ b/content/blog/iteration-reports/2021-03-01/index.md
@@ -1,8 +1,11 @@
 ---
-title: "March 1, 2021"
+title: "Feb 15 - 26, 2021"
 date: 2021-03-01
 iteration_start: 2021-02-15
 layout: iterationreport
+slug: "01"
+aliases:
+  - /blog/2021/03/march-1-2021/
 ---
 
 This iteration we continued to make progress on building out the new relational database for the Geniza project and importing existing data from spreadsheets. Database structure, admin interface, and data import for languages & scripts are complete; data import for library collections are complete but the admin editing story is not yet complete due to changes in the requirements. Database structure, and admin interface for documents and fragments are underway and far enough along to share a list of questions and necessary data work for the import to proceed, but have not yet been delivered for testing. In terms of design work, issues were delivered with proposed sitemap for sign off and mockups for the structure and content of the document detail page, but neither were closed.

--- a/content/blog/iteration-reports/2021-03-15/index.md
+++ b/content/blog/iteration-reports/2021-03-15/index.md
@@ -1,8 +1,11 @@
 ---
-title: "March 15, 2021"
+title: "Mar 1 — 12, 2021"
 date: 2021-03-15
 iteration_start: 2021-03-01
 layout: iterationreport
+slug: "15"
+aliases:
+  - /blog/2021/03/march-15-2021/
 ---
 
 Rolling velocity for this iteration increased from about 10 points to about 15 points, largely due to a substantial chunk of CDH website user stories that completed the testing process together after multiple iterations.

--- a/content/blog/iteration-reports/2021-03-29/index.md
+++ b/content/blog/iteration-reports/2021-03-29/index.md
@@ -1,14 +1,17 @@
 ---
-title: "March 29, 2021"
+title: "Mar 15 — 29, 2021"
 date: 2021-03-29
 iteration_start: 2021-03-15
 layout: iterationreport
+slug: "29"
+aliases:
+  - /blog/2021/03/march-29-2021/
 ---
 
-The points and total number of issues closed for the last iteration is quite high — 42 points total, 25 for cdhweb and 17 for geniza, which results in a rolling velocity of 27. I'd like to think this is a sign that we're gaining momentum on geniza work, but suspect that the high numbers are due to work that rolled over from the last iteration and a significant push to finish cdhweb 3.0. 
+The points and total number of issues closed for the last iteration is quite high — 42 points total, 25 for cdhweb and 17 for geniza, which results in a rolling velocity of 27. I'd like to think this is a sign that we're gaining momentum on geniza work, but suspect that the high numbers are due to work that rolled over from the last iteration and a significant push to finish cdhweb 3.0.
 
 ## Princeton Geniza Project
-We're continuing to make progress on building out the database and importing existing data. New features include a document suppression feature, automatic tracking of historic shelfmarks, and a "needs review" field where content editors can add notes about problems or questions in the data that are used to create a queue of records with problems to be addressed.  We also finished testing on data import issues from previous iterations, most notably preliminary document & fragment import. 
+We're continuing to make progress on building out the database and importing existing data. New features include a document suppression feature, automatic tracking of historic shelfmarks, and a "needs review" field where content editors can add notes about problems or questions in the data that are used to create a queue of records with problems to be addressed.  We also finished testing on data import issues from previous iterations, most notably preliminary document & fragment import.
 
 ## CDH Website
 We completed features related to blog migration and managing site menus and navigation via wagtail, and resolved a number of longstanding bugs that are no longer an issue now that the site is on wagtail instead of mezzanine. There are only a few small issues rolling over for final testing and review before the 3.0 release can be created and deployed production.

--- a/content/blog/iteration-reports/2021-04-12/index.md
+++ b/content/blog/iteration-reports/2021-04-12/index.md
@@ -1,18 +1,21 @@
 ---
-title: "April 12, 2021"
+title: "Mar 29 — Apr 9, 2021"
 date: 2021-04-12
 iteration_start: 2021-03-29
 layout: iterationreport
+slug: "12"
+aliases:
+  - /blog/2021/04/april-12-2021/
 ---
 
 The development points for this iteration were quite low (only 4 points), but our rolling velocity continues to be unnusually high (26 points) based on the last two iterations, which were included an enormous amount of work.
 
-Based on the design velocidy graph, we might be finding a new rhythm with design work on our new adjusted design schedule. 
+Based on the design velocidy graph, we might be finding a new rhythm with design work on our new adjusted design schedule.
 
 
 ## CDH Website
 We finally finished and deployed the 3.0 release, migrating content from the outdated and unsupported Mezzanine to Wagtail. This iteration included a few issues to close out the release, deploying the update and running the exodus script to convert content, and then some bugfixes and clean up work for a planned 3.0.1 release.
- 
+
 ## Princeton Geniza Project
 This iteration we finished some smaller work related to the database and admin sorting, and made progress on document detail designs. Multiple larger features were delivered late in the iteration, which didn't give enough time for testing to be completed.
 

--- a/content/blog/iteration-reports/2021-04-26/index.md
+++ b/content/blog/iteration-reports/2021-04-26/index.md
@@ -1,8 +1,11 @@
 ---
-title: "April 26, 2021"
+title: "Apr 12 — 23, 2021"
 date: 2021-04-26
 iteration_start: 2021-04-12
 layout: iterationreport
+slug: "26"
+aliases:
+  - /blog/2021/04/april-26-2021/
 ---
 
 This iteration we closed 11 development points for a rolling velocity of 19, still coming down from the massive number of points closed three iterations ago.
@@ -13,7 +16,7 @@ We made more improvements to the data import, fixing Language+Script mapping bas
 For design, wireframes for cluster view browse and search results pages for all screens (desktop, tablet, mobile) were all completed.
 
 ## CDH Website
-We fixed a couple more bugs in the 3.0 version and released a planned 3.0.1 cleanup release to remove exodus code specific to the shift to wagtail. This is a necessary step to removing mezzanine, which will finally let us upgrade to newer versions of Dljango and python. 
+We fixed a couple more bugs in the 3.0 version and released a planned 3.0.1 cleanup release to remove exodus code specific to the shift to wagtail. This is a necessary step to removing mezzanine, which will finally let us upgrade to newer versions of Dljango and python.
 
 
 ## Demos

--- a/content/blog/iteration-reports/2021-05-10/index.md
+++ b/content/blog/iteration-reports/2021-05-10/index.md
@@ -1,8 +1,11 @@
 ---
-title: "May 10, 2021"
+title: "Apr 26 — May 7, 2021"
 date: 2021-05-10
 iteration_start: 2021-04-26
 layout: iterationreport
+slug: "10"
+aliases:
+  - /blog/2021/05/may-10-2021/
 ---
 
 This iteration we closed 10 development points for a rolling velocity of 8. Our primary focus was on Princeton Geniza Project, but we did a small amount of planned work on the CDH website, ansible deploy scripts, and a very small amount of unplanned work on Shakespeare and Company Project to fix a time-sensitive bug.

--- a/content/blog/iteration-reports/2021-05-24/index.md
+++ b/content/blog/iteration-reports/2021-05-24/index.md
@@ -1,11 +1,14 @@
 ---
-title: "May 24, 2021"
+title: "May 10 — 21, 2021"
 date: 2021-05-24
 iteration_start: 2021-05-10
 layout: iterationreport
+slug: "24"
+aliases:
+  - /blog/2021/05/may-24-2021/
 ---
 
-This iteration we completed 18 development points on Geniza as we work towards a first release and migrating the metadata from the spreadsheet to the new relational database. We also completed a smattering of bugfixes and chores as part of planned maintenance work, and one unplanned bugfix. The 18 point total brings our rolling velocity up to 13. 
+This iteration we completed 18 development points on Geniza as we work towards a first release and migrating the metadata from the spreadsheet to the new relational database. We also completed a smattering of bugfixes and chores as part of planned maintenance work, and one unplanned bugfix. The 18 point total brings our rolling velocity up to 13.
 
 ## Princeton Geniza Project
 

--- a/content/blog/iteration-reports/2021-06-07/index.md
+++ b/content/blog/iteration-reports/2021-06-07/index.md
@@ -1,8 +1,11 @@
 ---
-title: "June 7, 2021"
+title: "May 24 — Jun 4, 2021"
 date: 2021-06-07
 iteration_start: 2021-05-24
 layout: iterationreport
+slug: "07"
+aliases:
+  - /blog/2021/06/june-7-2021/
 ---
 
 Our focus this iteration was on Geniza work as we finished out the second phase of work and created our first production release: we successfully migrated the Princeton Geniza Project metadata from a Google Sheets spreadsheet into the new relational database!

--- a/content/blog/iteration-reports/2021-07-06/index.md
+++ b/content/blog/iteration-reports/2021-07-06/index.md
@@ -1,8 +1,11 @@
 ---
-title: "July 6, 2021"
+title: "Jun 7 — 25, 2021"
 date: 2021-07-06
 iteration_start: 2021-06-07
 layout: iterationreport
+slug: "06"
+aliases:
+  - /blog/2021/07/july-6-2021/
 ---
 
 This past iteration, we split our focus between PPA and CDH web. On PPA, we worked on adding support for importing Gale/ECCO content. For CDH web, we worked on the first charter for CDH web, to articulate the roles and responsibilities and prioritize for the next  phases of work (chartering is not reflected in the GitHub issues reported here).  We extended the iteration to three weeks, to work around an off week for June 28 — July 2 (CDH staff R&D week).

--- a/content/blog/iteration-reports/2021-07-26/index.md
+++ b/content/blog/iteration-reports/2021-07-26/index.md
@@ -1,8 +1,11 @@
 ---
-title: "July 26, 2021"
+title: "Jul 5 — 23, 2021"
 date: 2021-07-26
 iteration_start: 2021-07-05
 layout: iterationreport
+slug: 26
+aliases:
+  - /blog/2021/07/july-26-2021/
 ---
 
 This iteration we made significant progress on PPA. All remaining planned work to support Gale/ECCO import and HathiTrust excerpts were moved to "development complete" status, but unfortunately testing issues related to indexing and keyword search were problematic and held up testing on a cluster of issues.

--- a/content/blog/iteration-reports/2021-08-09/index.md
+++ b/content/blog/iteration-reports/2021-08-09/index.md
@@ -1,8 +1,11 @@
 ---
-title: "August 9, 2021"
+title: "Jul 26 — Aug 6, 2021"
 date: 2021-08-09
 iteration_start: 2021-07-26
 layout: iterationreport
+slug: 09
+aliases:
+  - /blog/2021/08/august-9-2021/
 ---
 
 We had multiple projects active this iteration, roughly divided across developers on the team. The planned work for PPA spilled over and needed to be completed; work started on updates for CDH web identified in the recent project charter; and work continued on maintenance updates for Derrida's Margins.  We closed **24** issues and a total of **9** points for a rolling velocity of **11.3**. The lower velocity reflects the kind of work we're doing (including some maintenance), as well as other things going on, including the transition with some staff starting to work on campus again.


### PR DESCRIPTION
- renames all current iteration reports so title reflects iteration dates covered by the report
- adds alias with previous urls so existing links in meeting notes or slack will still resolve
- configures slug based on report date for simpler urls that are not based on post titles (see note)
- updates readme notes & archetype page bundle for revised title format and slug


Notes:
- I went with abbreviated names because it makes them easier to scan in the sidebar
- Using Hugo permalink configuration instead of slugs in each post would be much better, but that doesn't seem to be available for subsections. It might be better to make iteration reports a top-level content type, and we may need to do that at some point (we already have a lot of content), but then we'd lose the default docsy blog templates. There's probably a way to take advantage of them if/when we move the content, but I'm not sure what it is yet.