### PR TITLE
Draft schedule for 2023 Q1

### DIFF
--- a/assets/scss/_quarterly_schedule.scss
+++ b/assets/scss/_quarterly_schedule.scss
@@ -102,4 +102,11 @@
 		}
 	}
 
+	.risk {
+		background-color: #fcd030;
+		&.partial {
+			background-color: rgba(252, 208, 48, 0.5);					
+		}	
+	}
+
 }

--- a/content/blog/2022-12-20-winter-schedule.md
+++ b/content/blog/2022-12-20-winter-schedule.md
@@ -1,0 +1,9 @@
+---
+title: "2023 Q1 Schedule"
+date: 2022-12-20
+layout: quarterlyschedule
+date_range:
+    start: "2023-01-01"
+    end: "2023-05-01"
+---
+

--- a/content/blog/2022-12-20-winter-schedule.md
+++ b/content/blog/2022-12-20-winter-schedule.md
@@ -4,6 +4,6 @@ date: 2022-12-20
 layout: quarterlyschedule
 date_range:
     start: "2023-01-01"
-    end: "2023-05-01"
+    end: "2023-05-15"
 ---
 

--- a/data/iterations.json
+++ b/data/iterations.json
@@ -786,7 +786,7 @@
         "partial": ["ppa"],
         "notes": {
             "ppa": ["", "release enhancements"],
-            "other": ["clustering sprint", "wintersession"]
+            "other": ["wintersession", "wintersession"]
         }
     },
     {
@@ -809,7 +809,7 @@
         "from": "2023-03-13",
         "to": "2023-03-24",
         "projects": ["lenape", "risk", "other"],
-        "partial": ["lenape"],
+        "partial": ["lenape", "risk"],
          "notes": {
             "other": ["spring break"]
         }

--- a/data/iterations.json
+++ b/data/iterations.json
@@ -802,30 +802,38 @@
     {
         "from": "2023-02-27",
         "to": "2023-03-10",
-        "projects": ["lenape"],
+        "projects": ["lenape", "risk"],
         "partial": ["lenape"]
     },
     {
         "from": "2023-03-13",
         "to": "2023-03-24",
-        "projects": ["lenape"],
-        "partial": ["lenape"]
+        "projects": ["lenape", "risk", "other"],
+        "partial": ["lenape"],
+         "notes": {
+            "other": ["spring break"]
+        }
     },
     {
         "from": "2023-03-27",
         "to": "2023-04-07",
-        "projects": ["lenape"],
+        "projects": ["lenape", "risk"],
         "partial": ["lenape"]
     },
     {
         "from": "2023-04-10",
         "to": "2023-04-21",
-        "projects": ["startwords"]
+        "projects": ["startwords", "risk"],
+        "partial": ["risk"]
     },
     {
         "from": "2023-04-24",
-        "to": "2023-05-05"
-
+        "to": "2023-05-05",
+        "projects": ["startwords", "risk"],
+        "partial": ["risk"]
+    },
+    {
+        "from": "2023-05-08",
+        "to": "2023-05-19"
     }
-
 ]

--- a/data/iterations.json
+++ b/data/iterations.json
@@ -762,6 +762,70 @@
         "to": "2022-12-30",
         "comment": "holidays",
         "skip": "yes"
+    },
+    {
+        "from": "2023-01-02",
+        "to": "2023-01-06",
+        "comment": "holidays",
+        "skip": "yes"
+    },
+    {
+        "from": "2023-01-09",
+        "to": "2023-01-13",
+        "projects": ["lenape", "ppa", "other"],
+        "partial": ["lenape", "ppa"],
+        "notes": {
+            "other": ["HDSI"]
+        }
+
+    },
+    {
+        "from": "2023-01-16",
+        "to": "2023-01-27",
+        "projects": ["lenape", "ppa", "other"],
+        "partial": ["ppa"],
+        "notes": {
+            "ppa": ["", "release enhancements"],
+            "other": ["clustering sprint", "wintersession"]
+        }
+    },
+    {
+        "from": "2023-01-30",
+        "to": "2023-02-10",
+        "projects": ["lenape"]
+    },
+    {
+        "from": "2023-02-13",
+        "to": "2023-02-24",
+        "projects": ["lenape"]
+    },
+    {
+        "from": "2023-02-27",
+        "to": "2023-03-10",
+        "projects": ["lenape"],
+        "partial": ["lenape"]
+    },
+    {
+        "from": "2023-03-13",
+        "to": "2023-03-24",
+        "projects": ["lenape"],
+        "partial": ["lenape"]
+    },
+    {
+        "from": "2023-03-27",
+        "to": "2023-04-07",
+        "projects": ["lenape"],
+        "partial": ["lenape"]
+    },
+    {
+        "from": "2023-04-10",
+        "to": "2023-04-21",
+        "projects": ["startwords"]
+    },
+    {
+        "from": "2023-04-24",
+        "to": "2023-05-05"
+
     }
 
 ]


### PR DESCRIPTION
preview draft schedule: https://cdhprinceton-dev-design-pr-45.onrender.com/blog/2022/12/2023-q1-schedule/ 

general notes:
- treating week of Jan 9 as pseudo iteration; don't expect a lot to get done, but will report on any work completed as part of the iteration before the holidays
- Lenape running through end of March; primary in Jan/Feb,  partial/back-burner in March
 - aim for PPA release to conclude current enhancements by end of January
 - simulating risk project now starting in March
 - active briefly on startwords when Grant gets back

questions
- do we want Startwords on the schedule earlier (as back-burner / secondary project), and if so when?
- should we track S&co RC project on this calendar? and if so, when do we think active dev will start?